### PR TITLE
Fix: Standalone app panic on run #18

### DIFF
--- a/games/template/stand-alone/pixel.toml.temp
+++ b/games/template/stand-alone/pixel.toml.temp
@@ -6,4 +6,4 @@
 [pixel]
 standalone = true
 rust_pixel = "$RUST_PIXEL_ROOT"
-cargo_pixel = "0.4.0"
+cargo_pixel = "0.5.1"

--- a/tools/cargo-pixel/src/main.rs
+++ b/tools/cargo-pixel/src/main.rs
@@ -464,7 +464,9 @@ fn check_pixel_toml() -> PixelContext {
         if let Some(cargo_pixel) = pixel.get("cargo_pixel") {
             let cps = cargo_pixel.to_string();
             if cps != "\"0.5.1\"" {
-                panic!("Please update cargo pixel: cargo install --path tools/cargo-pixel --root ~/.cargo");
+                println!(
+                    "The cargo_pixel version in pixel.toml is {cps}, the latest version is 0.5.1"
+                );
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/zipxing/rust_pixel/issues/18

- Update cargo_pixel version in pixel.toml template
- Message instead of panic if there is a version conflict

Not totally sure if removing the panic is a good idea. 

Updating cargo_pixel addresses the case where a game is from a later version of `cargo_pixel` but doesn't address the issue of the game version is behind the installed cargo_pixel version. 